### PR TITLE
feat: implementar classe para salvar estado dos carros

### DIFF
--- a/CorridaDeGuerra/Classes/Utils/CorridaMemento.cs
+++ b/CorridaDeGuerra/Classes/Utils/CorridaMemento.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using CorridaDeGuerra.Classes.Carros;
+
+namespace CorridaDeGuerra.Classes.Utils
+{
+    public class CorridaMemento
+    {
+        public List<Carro> EstadoCarros { get; }
+
+        public CorridaMemento(List<Carro> estadoCarros)
+        {
+            EstadoCarros = new List<Carro>(estadoCarros);
+        }
+    }
+}


### PR DESCRIPTION
Implementa a classe `CorridaMemento` que usa o padrão Memento para salvar o estado atual dos carros na corrida. 
A classe armazena uma cópia do estado dos carros, permitindo que o jogo restaure esse estado em um ponto posterior.
